### PR TITLE
Some refactoring and minor clean up

### DIFF
--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -22,7 +22,7 @@ namespace MicroRuleEngine.Tests
                                 Operator = ExpressionType.Equal.ToString("g"),
                                 TargetValue = "AUS"
                             };
-            MRE engine = new MRE();
+            MRE engine = MRE.Instance;
             var compiledRule = engine.Compile<Order>(rule);
             bool passes = compiledRule(order);
             Assert.IsTrue(passes);
@@ -53,7 +53,7 @@ namespace MicroRuleEngine.Tests
                     }
                 }
                             };
-            MRE engine = new MRE();
+            MRE engine = MRE.Instance;
             var fakeName = engine.Compile<Order>(rule);
             bool passes = fakeName(order);
             Assert.IsTrue(passes);
@@ -72,7 +72,7 @@ namespace MicroRuleEngine.Tests
                                 Operator = "HasItem", //The Order Object Contains a method named 'HasItem' that returns true/false
                                 Inputs = new List<object> { "Test" }
                             };
-            MRE engine = new MRE();
+            MRE engine = MRE.Instance;
             var boolMethod = engine.Compile<Order>(rule);
             bool passes = boolMethod(order);
             Assert.IsTrue(passes);
@@ -90,10 +90,10 @@ namespace MicroRuleEngine.Tests
             Rule rule = new Rule
                             {
                                 MemberName = "Customer.FirstName",
-                                Operator = "EndsWith",//Regular method that exists on string.. As a note expression methods are not available
+                                Operator = "EndsWith", //Regular method that exists on string.. As a note expression methods are not available
                                 Inputs = new List<object> { "ohn" }
                             };
-            MRE engine = new MRE();
+            MRE engine = MRE.Instance;
             var childPropCheck = engine.Compile<Order>(rule);
             bool passes = childPropCheck(order);
             Assert.IsTrue(passes);
@@ -103,7 +103,7 @@ namespace MicroRuleEngine.Tests
             Assert.IsFalse(passes);
         }
 
-        public void RegexIsMatch()//Had to add a Regex evaluator to make it feel 'Complete'
+        public void RegexIsMatch() //Had to add a Regex evaluator to make it feel 'Complete'
         {
             Order order = GetOrder();
             Rule rule = new Rule
@@ -112,7 +112,7 @@ namespace MicroRuleEngine.Tests
                                 Operator = "IsMatch",
                                 TargetValue = @"^[a-zA-Z0-9]*$"
                             };
-            MRE engine = new MRE();
+            MRE engine = MRE.Instance;
             var regexCheck = engine.Compile<Order>(rule);
             bool passes = regexCheck(order);
             Assert.IsTrue(passes);

--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -13,6 +13,21 @@ namespace MicroRuleEngine.Tests
     public class ExampleUsage
     {
         [TestMethod]
+        public void ChildPropertiesOfNull()
+        {
+            Order order = GetOrder();
+            order.Customer = null;
+            Rule rule = new Rule
+            {
+                MemberName = "Customer.Country.CountryCode",
+                Operator = ExpressionType.Equal.ToString("g"),
+                TargetValue = "AUS"
+            };
+            var compiledRule = MRE.Instance.Compile<Order>(rule);
+            bool passes = compiledRule(order);
+            Assert.IsFalse(passes);
+        }
+        [TestMethod]
         public void ChildProperties()
         {
             Order order = GetOrder();
@@ -112,6 +127,22 @@ namespace MicroRuleEngine.Tests
 
             order.Customer.FirstName = "jane";
             passes = childPropCheck(order);
+            Assert.IsFalse(passes);
+        }
+
+        [TestMethod]
+        public void ChildPropertyOfNullBooleanMethods()
+        {
+            Order order = GetOrder();
+            order.Customer = null;
+            Rule rule = new Rule
+            {
+                MemberName = "Customer.FirstName",
+                Operator = "EndsWith", //Regular method that exists on string.. As a note expression methods are not available
+                Inputs = new List<object> { "ohn" }
+            };
+            var childPropCheck = MRE.Instance.Compile<Order>(rule);
+            bool passes = childPropCheck(order);
             Assert.IsFalse(passes);
         }
 

--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -19,7 +19,7 @@ namespace MicroRuleEngine.Tests
             Rule rule = new Rule
                             {
                                 MemberName = "Customer.Country.CountryCode",
-                                Operator = System.Linq.Expressions.ExpressionType.Equal.ToString("g"),
+                                Operator = ExpressionType.Equal.ToString("g"),
                                 TargetValue = "AUS"
                             };
             MRE engine = new MRE();
@@ -38,9 +38,9 @@ namespace MicroRuleEngine.Tests
             Order order = GetOrder();
             Rule rule = new Rule
                             {
-                                Operator = System.Linq.Expressions.ExpressionType.AndAlso.ToString("g"),
+                                Operator = ExpressionType.AndAlso.ToString("g"),
                                 Rules = new List<Rule>
-                            {
+                                            {
                     new Rule { MemberName = "Customer.LastName", TargetValue = "Doe", Operator = "Equal"},
                     new Rule
                         { 

--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -23,7 +23,7 @@ namespace MicroRuleEngine.Tests
                                 TargetValue = "AUS"
                             };
             MRE engine = new MRE();
-            var compiledRule = engine.CompileRule<Order>(rule);
+            var compiledRule = engine.Evaluate<Order>(rule);
             bool passes = compiledRule(order);
             Assert.IsTrue(passes);
 
@@ -54,7 +54,7 @@ namespace MicroRuleEngine.Tests
                 }
                             };
             MRE engine = new MRE();
-            var fakeName = engine.CompileRule<Order>(rule);
+            var fakeName = engine.Evaluate<Order>(rule);
             bool passes = fakeName(order);
             Assert.IsTrue(passes);
 
@@ -73,7 +73,7 @@ namespace MicroRuleEngine.Tests
                                 Inputs = new List<object> { "Test" }
                             };
             MRE engine = new MRE();
-            var boolMethod = engine.CompileRule<Order>(rule);
+            var boolMethod = engine.Evaluate<Order>(rule);
             bool passes = boolMethod(order);
             Assert.IsTrue(passes);
 
@@ -94,7 +94,7 @@ namespace MicroRuleEngine.Tests
                                 Inputs = new List<object> { "ohn" }
                             };
             MRE engine = new MRE();
-            var childPropCheck = engine.CompileRule<Order>(rule);
+            var childPropCheck = engine.Evaluate<Order>(rule);
             bool passes = childPropCheck(order);
             Assert.IsTrue(passes);
 
@@ -113,7 +113,7 @@ namespace MicroRuleEngine.Tests
                                 TargetValue = @"^[a-zA-Z0-9]*$"
                             };
             MRE engine = new MRE();
-            var regexCheck = engine.CompileRule<Order>(rule);
+            var regexCheck = engine.Evaluate<Order>(rule);
             bool passes = regexCheck(order);
             Assert.IsTrue(passes);
 

--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -23,7 +23,7 @@ namespace MicroRuleEngine.Tests
                                 TargetValue = "AUS"
                             };
             MRE engine = new MRE();
-            var compiledRule = engine.Evaluate<Order>(rule);
+            var compiledRule = engine.Compile<Order>(rule);
             bool passes = compiledRule(order);
             Assert.IsTrue(passes);
 
@@ -54,7 +54,7 @@ namespace MicroRuleEngine.Tests
                 }
                             };
             MRE engine = new MRE();
-            var fakeName = engine.Evaluate<Order>(rule);
+            var fakeName = engine.Compile<Order>(rule);
             bool passes = fakeName(order);
             Assert.IsTrue(passes);
 
@@ -69,11 +69,11 @@ namespace MicroRuleEngine.Tests
             Order order = GetOrder();
             Rule rule = new Rule
                             {
-                                Operator = "HasItem",//The Order Object Contains a method named 'HasItem' that returns true/false
+                                Operator = "HasItem", //The Order Object Contains a method named 'HasItem' that returns true/false
                                 Inputs = new List<object> { "Test" }
                             };
             MRE engine = new MRE();
-            var boolMethod = engine.Evaluate<Order>(rule);
+            var boolMethod = engine.Compile<Order>(rule);
             bool passes = boolMethod(order);
             Assert.IsTrue(passes);
 
@@ -94,7 +94,7 @@ namespace MicroRuleEngine.Tests
                                 Inputs = new List<object> { "ohn" }
                             };
             MRE engine = new MRE();
-            var childPropCheck = engine.Evaluate<Order>(rule);
+            var childPropCheck = engine.Compile<Order>(rule);
             bool passes = childPropCheck(order);
             Assert.IsTrue(passes);
 
@@ -113,7 +113,7 @@ namespace MicroRuleEngine.Tests
                                 TargetValue = @"^[a-zA-Z0-9]*$"
                             };
             MRE engine = new MRE();
-            var regexCheck = engine.Evaluate<Order>(rule);
+            var regexCheck = engine.Compile<Order>(rule);
             bool passes = regexCheck(order);
             Assert.IsTrue(passes);
 

--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -22,8 +22,7 @@ namespace MicroRuleEngine.Tests
                                 Operator = ExpressionType.Equal.ToString("g"),
                                 TargetValue = "AUS"
                             };
-            MRE engine = MRE.Instance;
-            var compiledRule = engine.Compile<Order>(rule);
+            var compiledRule = MRE.Instance.Compile<Order>(rule);
             bool passes = compiledRule(order);
             Assert.IsTrue(passes);
 
@@ -39,22 +38,37 @@ namespace MicroRuleEngine.Tests
             Rule rule = new Rule
                             {
                                 Operator = ExpressionType.AndAlso.ToString("g"),
-                                Rules = new List<Rule>
-                                            {
-                    new Rule { MemberName = "Customer.LastName", TargetValue = "Doe", Operator = "Equal"},
-                    new Rule
-                        { 
-                        Operator = "Or",
-                        Rules = new List<Rule>
-                                    {
-                            new Rule { MemberName = "Customer.FirstName", TargetValue = "John", Operator = "Equal"},
-                            new Rule { MemberName = "Customer.FirstName", TargetValue = "Jane", Operator = "Equal"}
-                        }
-                    }
-                }
+                                Rules =
+                                    new List<Rule>
+                                        {
+                                            new Rule
+                                                {
+                                                    MemberName = "Customer.LastName",
+                                                    TargetValue = "Doe",
+                                                    Operator = "Equal"
+                                                },
+                                            new Rule
+                                                {
+                                                    Operator = "Or",
+                                                    Rules = new List<Rule>
+                                                                {
+                                                                    new Rule
+                                                                        {
+                                                                            MemberName = "Customer.FirstName",
+                                                                            TargetValue = "John",
+                                                                            Operator = "Equal"
+                                                                        },
+                                                                    new Rule
+                                                                        {
+                                                                            MemberName = "Customer.FirstName",
+                                                                            TargetValue = "Jane",
+                                                                            Operator = "Equal"
+                                                                        }
+                                                                }
+                                                }
+                                        }
                             };
-            MRE engine = MRE.Instance;
-            var fakeName = engine.Compile<Order>(rule);
+            var fakeName = MRE.Instance.Compile<Order>(rule);
             bool passes = fakeName(order);
             Assert.IsTrue(passes);
 
@@ -72,8 +86,7 @@ namespace MicroRuleEngine.Tests
                                 Operator = "HasItem", //The Order Object Contains a method named 'HasItem' that returns true/false
                                 Inputs = new List<object> { "Test" }
                             };
-            MRE engine = MRE.Instance;
-            var boolMethod = engine.Compile<Order>(rule);
+            var boolMethod = MRE.Instance.Compile<Order>(rule);
             bool passes = boolMethod(order);
             Assert.IsTrue(passes);
 
@@ -93,8 +106,7 @@ namespace MicroRuleEngine.Tests
                                 Operator = "EndsWith", //Regular method that exists on string.. As a note expression methods are not available
                                 Inputs = new List<object> { "ohn" }
                             };
-            MRE engine = MRE.Instance;
-            var childPropCheck = engine.Compile<Order>(rule);
+            var childPropCheck = MRE.Instance.Compile<Order>(rule);
             bool passes = childPropCheck(order);
             Assert.IsTrue(passes);
 
@@ -112,8 +124,7 @@ namespace MicroRuleEngine.Tests
                                 Operator = "IsMatch",
                                 TargetValue = @"^[a-zA-Z0-9]*$"
                             };
-            MRE engine = MRE.Instance;
-            var regexCheck = engine.Compile<Order>(rule);
+            var regexCheck = MRE.Instance.Compile<Order>(rule);
             bool passes = regexCheck(order);
             Assert.IsTrue(passes);
 
@@ -124,26 +135,17 @@ namespace MicroRuleEngine.Tests
 
         public Order GetOrder()
         {
-            Order order = new Order
-                              {
-                                  OrderId = 1,
-                                  Customer = new Customer
-                                                 {
-                                                     FirstName = "John",
-                                                     LastName = "Doe",
-                                                     Country = new Country
-                                                                   {
-                                                                       CountryCode = "AUS"
-                                                                   }
-                                                 },
-                                  Items = new List<Item>
-                                              {
-                                                  new Item {ItemCode = "MM23", Cost = 5.25M},
-                                                  new Item {ItemCode = "LD45", Cost = 5.25M},
-                                                  new Item {ItemCode = "Test", Cost = 3.33M},
-                                              }
-                              };
-            return order;
+            return new Order
+                       {
+                           OrderId = 1,
+                           Customer = Customer.Make("John", "Doe", "AUS"),
+                           Items = new List<Item>
+                                       {
+                                           Item.Make("MM23", 5.25M),
+                                           Item.Make("LD45", 5.25M),
+                                           Item.Make("Test", 3.33M),
+                                       }
+                       };
         }
     }
 }

--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Text;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MicroRuleEngine.Tests.Models;
 
@@ -13,17 +12,16 @@ namespace MicroRuleEngine.Tests
     [TestClass]
     public class ExampleUsage
     {
-
         [TestMethod]
         public void ChildProperties()
         {
-            Order order = this.GetOrder();
-            Rule rule = new Rule()
-            {
-                MemberName = "Customer.Country.CountryCode",
-                Operator = System.Linq.Expressions.ExpressionType.Equal.ToString("g"),
-                TargetValue = "AUS"
-            };
+            Order order = GetOrder();
+            Rule rule = new Rule
+                            {
+                                MemberName = "Customer.Country.CountryCode",
+                                Operator = System.Linq.Expressions.ExpressionType.Equal.ToString("g"),
+                                TargetValue = "AUS"
+                            };
             MRE engine = new MRE();
             var compiledRule = engine.CompileRule<Order>(rule);
             bool passes = compiledRule(order);
@@ -37,22 +35,24 @@ namespace MicroRuleEngine.Tests
         [TestMethod]
         public void ConditionalLogic()
         {
-            Order order = this.GetOrder();
-            Rule rule = new Rule()
-            {
-                Operator = System.Linq.Expressions.ExpressionType.AndAlso.ToString("g"),
-                Rules = new List<Rule>()
-                {
-                    new Rule(){ MemberName = "Customer.LastName", TargetValue = "Doe", Operator = "Equal"},
-                    new Rule(){ 
+            Order order = GetOrder();
+            Rule rule = new Rule
+                            {
+                                Operator = System.Linq.Expressions.ExpressionType.AndAlso.ToString("g"),
+                                Rules = new List<Rule>
+                            {
+                    new Rule { MemberName = "Customer.LastName", TargetValue = "Doe", Operator = "Equal"},
+                    new Rule
+                        { 
                         Operator = "Or",
-                        Rules = new List<Rule>(){
-                            new Rule(){ MemberName = "Customer.FirstName", TargetValue = "John", Operator = "Equal"},
-                            new Rule(){ MemberName = "Customer.FirstName", TargetValue = "Jane", Operator = "Equal"}
+                        Rules = new List<Rule>
+                                    {
+                            new Rule { MemberName = "Customer.FirstName", TargetValue = "John", Operator = "Equal"},
+                            new Rule { MemberName = "Customer.FirstName", TargetValue = "Jane", Operator = "Equal"}
                         }
                     }
                 }
-            };
+                            };
             MRE engine = new MRE();
             var fakeName = engine.CompileRule<Order>(rule);
             bool passes = fakeName(order);
@@ -66,12 +66,12 @@ namespace MicroRuleEngine.Tests
         [TestMethod]
         public void BooleanMethods()
         {
-            Order order = this.GetOrder();
-            Rule rule = new Rule()
-            {
-                Operator = "HasItem",//The Order Object Contains a method named 'HasItem' that returns true/false
-                Inputs = new List<object>{"Test"}
-            };
+            Order order = GetOrder();
+            Rule rule = new Rule
+                            {
+                                Operator = "HasItem",//The Order Object Contains a method named 'HasItem' that returns true/false
+                                Inputs = new List<object> { "Test" }
+                            };
             MRE engine = new MRE();
             var boolMethod = engine.CompileRule<Order>(rule);
             bool passes = boolMethod(order);
@@ -86,13 +86,13 @@ namespace MicroRuleEngine.Tests
         [TestMethod]
         public void ChildPropertyBooleanMethods()
         {
-            Order order = this.GetOrder();
-            Rule rule = new Rule()
-            { 
-                MemberName = "Customer.FirstName",
-                Operator = "EndsWith",//Regular method that exists on string.. As a note expression methods are not available
-                Inputs = new List<object> { "ohn" }
-            };
+            Order order = GetOrder();
+            Rule rule = new Rule
+                            {
+                                MemberName = "Customer.FirstName",
+                                Operator = "EndsWith",//Regular method that exists on string.. As a note expression methods are not available
+                                Inputs = new List<object> { "ohn" }
+                            };
             MRE engine = new MRE();
             var childPropCheck = engine.CompileRule<Order>(rule);
             bool passes = childPropCheck(order);
@@ -105,13 +105,13 @@ namespace MicroRuleEngine.Tests
 
         public void RegexIsMatch()//Had to add a Regex evaluator to make it feel 'Complete'
         {
-            Order order = this.GetOrder();
-            Rule rule = new Rule()
-            {
-                MemberName = "Customer.FirstName",
-                Operator = "IsMatch",
-                TargetValue = @"^[a-zA-Z0-9]*$"
-            };
+            Order order = GetOrder();
+            Rule rule = new Rule
+                            {
+                                MemberName = "Customer.FirstName",
+                                Operator = "IsMatch",
+                                TargetValue = @"^[a-zA-Z0-9]*$"
+                            };
             MRE engine = new MRE();
             var regexCheck = engine.CompileRule<Order>(rule);
             bool passes = regexCheck(order);
@@ -124,24 +124,25 @@ namespace MicroRuleEngine.Tests
 
         public Order GetOrder()
         {
-            Order order = new Order()
-            {
-                OrderId = 1,
-                Customer = new Customer()
-                {
-                    FirstName = "John",
-                    LastName = "Doe",
-                    Country = new Country()
-                    {
-                        CountryCode = "AUS"
-                    }
-                },
-                Items = new List<Item>(){
-                    new Item(){ ItemCode = "MM23", Cost=5.25M},
-                    new Item(){ ItemCode = "LD45", Cost=5.25M},
-                    new Item(){ ItemCode = "Test", Cost=3.33M},
-                }
-            };
+            Order order = new Order
+                              {
+                                  OrderId = 1,
+                                  Customer = new Customer
+                                                 {
+                                                     FirstName = "John",
+                                                     LastName = "Doe",
+                                                     Country = new Country
+                                                                   {
+                                                                       CountryCode = "AUS"
+                                                                   }
+                                                 },
+                                  Items = new List<Item>
+                                              {
+                                                  new Item {ItemCode = "MM23", Cost = 5.25M},
+                                                  new Item {ItemCode = "LD45", Cost = 5.25M},
+                                                  new Item {ItemCode = "Test", Cost = 3.33M},
+                                              }
+                              };
             return order;
         }
     }

--- a/MicroRuleEngine.Tests/MicroRuleEngine.Tests.csproj
+++ b/MicroRuleEngine.Tests/MicroRuleEngine.Tests.csproj
@@ -45,6 +45,13 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Models\Country.cs" />
+    <Compile Include="Models\Customer.cs" />
+    <Compile Include="Models\Item.cs" />
+    <Compile Include="Models\ItemRebateVisitor.cs" />
+    <Compile Include="Models\ItemTotalVisitor.cs" />
+    <Compile Include="Models\IVisitable.cs" />
+    <Compile Include="Models\IVisitor.cs" />
     <Compile Include="Models\Order.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ExampleUsage.cs" />

--- a/MicroRuleEngine.Tests/Models/Country.cs
+++ b/MicroRuleEngine.Tests/Models/Country.cs
@@ -9,5 +9,13 @@
         {
             visitor.Visit(this);
         }
+
+        public static Country Make(string countryCode)
+        {
+            return new Country
+                       {
+                           CountryCode = countryCode
+                       };
+        }
     }
 }

--- a/MicroRuleEngine.Tests/Models/Country.cs
+++ b/MicroRuleEngine.Tests/Models/Country.cs
@@ -1,0 +1,13 @@
+﻿namespace MicroRuleEngine.Tests.Models
+{
+    public class Country
+        : IVisitable<Country>
+    {
+        public string CountryCode { get; set; }
+
+        public void Accept(IVisitor<Country> visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/MicroRuleEngine.Tests/Models/Customer.cs
+++ b/MicroRuleEngine.Tests/Models/Customer.cs
@@ -11,5 +11,15 @@
         {
             visitor.Visit(this);
         }
+
+        public static Customer Make(string firstName, string lastName, string countryCode)
+        {
+            return new Customer
+                       {
+                           FirstName = firstName,
+                           LastName = lastName,
+                           Country = Country.Make(countryCode)
+                       };
+        }
     }
 }

--- a/MicroRuleEngine.Tests/Models/Customer.cs
+++ b/MicroRuleEngine.Tests/Models/Customer.cs
@@ -1,0 +1,15 @@
+﻿namespace MicroRuleEngine.Tests.Models
+{
+    public class Customer
+        : IVisitable<Customer>
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public Country Country { get; set; }
+
+        public void Accept(IVisitor<Customer> visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/MicroRuleEngine.Tests/Models/IVisitable.cs
+++ b/MicroRuleEngine.Tests/Models/IVisitable.cs
@@ -1,0 +1,7 @@
+﻿namespace MicroRuleEngine.Tests.Models
+{
+    public interface IVisitable<out T>
+    {
+        void Accept(IVisitor<T> visitor);
+    }
+}

--- a/MicroRuleEngine.Tests/Models/IVisitor.cs
+++ b/MicroRuleEngine.Tests/Models/IVisitor.cs
@@ -1,0 +1,7 @@
+﻿namespace MicroRuleEngine.Tests.Models
+{
+    public interface IVisitor<in T>
+    {
+        void Visit(T element);
+    }
+}

--- a/MicroRuleEngine.Tests/Models/Item.cs
+++ b/MicroRuleEngine.Tests/Models/Item.cs
@@ -10,5 +10,10 @@
         {
             visitor.Visit(this);
         }
+
+        public static Item Make(string itemCode, decimal cost)
+        {
+            return new Item { ItemCode = itemCode, Cost = cost };
+        }
     }
 }

--- a/MicroRuleEngine.Tests/Models/Item.cs
+++ b/MicroRuleEngine.Tests/Models/Item.cs
@@ -1,0 +1,14 @@
+﻿namespace MicroRuleEngine.Tests.Models
+{
+    public class Item :
+        IVisitable<Item>
+    {
+        public decimal Cost { get; set; }
+        public string ItemCode { get; set; }
+
+        public void Accept(IVisitor<Item> visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/MicroRuleEngine.Tests/Models/ItemRebateVisitor.cs
+++ b/MicroRuleEngine.Tests/Models/ItemRebateVisitor.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace MicroRuleEngine.Tests.Models
+{
+    public class ItemRebateVisitor
+        : IVisitor<Item>
+    {
+        private readonly Func<Item, bool> _rule;
+        private decimal _rebate;
+
+        public ItemRebateVisitor(Func<Item, bool> rule)
+        {
+            _rule = rule;
+            _rebate = 0;
+        }
+
+        public void Visit(Item element)
+        {
+            if (_rule(element))
+                _rebate = _rebate + (element.Cost * (decimal)0.1);
+        }
+    }
+}

--- a/MicroRuleEngine.Tests/Models/ItemRebateVisitor.cs
+++ b/MicroRuleEngine.Tests/Models/ItemRebateVisitor.cs
@@ -17,7 +17,7 @@ namespace MicroRuleEngine.Tests.Models
         public void Visit(Item element)
         {
             if (_rule(element))
-                _rebate = _rebate + (element.Cost * (decimal)0.1);
+                _rebate = _rebate + (element.Cost * 0.1M);
         }
     }
 }

--- a/MicroRuleEngine.Tests/Models/ItemTotalVisitor.cs
+++ b/MicroRuleEngine.Tests/Models/ItemTotalVisitor.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace MicroRuleEngine.Tests.Models
+{
+    public class ItemTotalVisitor
+        : IVisitor<Item>
+    {
+        private readonly Func<Item, bool> _rule;
+        private decimal _total;
+
+        public ItemTotalVisitor(Func<Item, bool> rule)
+        {
+            _rule = rule;
+            _total = 0;
+        }
+
+        public void Visit(Item element)
+        {
+            if (_rule(element))
+                _total = _total + element.Cost;
+        }
+    }
+}

--- a/MicroRuleEngine.Tests/Models/Order.cs
+++ b/MicroRuleEngine.Tests/Models/Order.cs
@@ -19,18 +19,22 @@ namespace MicroRuleEngine.Tests.Models
             return this.Items.Any(x => x.ItemCode == itemCode);
         }
     }
-    public class Item{
-        public decimal Cost{get;set;}
-        public string ItemCode{get;set;}
+
+    public class Item
+    {
+        public decimal Cost { get; set; }
+        public string ItemCode { get; set; }
     }
 
     public class Customer
     {
-        public string FirstName {get;set;}
+        public string FirstName { get; set; }
         public string LastName { get; set; }
-        public Country Country {get;set;}
+        public Country Country { get; set; }
     }
-    public class Country{
-        public string CountryCode{get;set;}
+
+    public class Country
+    {
+        public string CountryCode { get; set; }
     }
 }

--- a/MicroRuleEngine.Tests/Models/Order.cs
+++ b/MicroRuleEngine.Tests/Models/Order.cs
@@ -3,36 +3,26 @@ using System.Linq;
 
 namespace MicroRuleEngine.Tests.Models
 {
-    public class Order
+    public class Order :
+        IVisitable<Order>
     {
         public Order()
         {
             Items = new List<Item>();
         }
+
         public int OrderId { get; set; }
         public Customer Customer { get; set; }
         public List<Item> Items { get; set; }
+
         public bool HasItem(string itemCode)
         {
             return Items.Any(x => x.ItemCode == itemCode);
         }
-    }
 
-    public class Item
-    {
-        public decimal Cost { get; set; }
-        public string ItemCode { get; set; }
-    }
-
-    public class Customer
-    {
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public Country Country { get; set; }
-    }
-
-    public class Country
-    {
-        public string CountryCode { get; set; }
+        public void Accept(IVisitor<Order> visitor)
+        {
+            visitor.Visit(this);
+        }
     }
 }

--- a/MicroRuleEngine.Tests/Models/Order.cs
+++ b/MicroRuleEngine.Tests/Models/Order.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace MicroRuleEngine.Tests.Models
 {
@@ -9,14 +7,14 @@ namespace MicroRuleEngine.Tests.Models
     {
         public Order()
         {
-            this.Items = new List<Item>();
+            Items = new List<Item>();
         }
         public int OrderId { get; set; }
         public Customer Customer { get; set; }
         public List<Item> Items { get; set; }
         public bool HasItem(string itemCode)
         {
-            return this.Items.Any(x => x.ItemCode == itemCode);
+            return Items.Any(x => x.ItemCode == itemCode);
         }
     }
 

--- a/MicroRuleEngine.Tests/Properties/AssemblyInfo.cs
+++ b/MicroRuleEngine.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/MicroRuleEngine/ExpressionBuilder.cs
+++ b/MicroRuleEngine/ExpressionBuilder.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+
+namespace MicroRuleEngine
+{
+    internal static class ExpressionBuilder
+    {
+        private const string StrIsMatch = "IsMatch";
+
+        private const string StrNull = "null";
+
+        private static readonly ExpressionType[] NestedOperators =
+        {
+            ExpressionType.And,
+            ExpressionType.AndAlso,
+            ExpressionType.Or,
+            ExpressionType.OrElse
+        };
+
+        public static Expression Build<T>(Rule rule, ParameterExpression parameterExpression)
+        {
+            ExpressionType nestedOperator;
+            return Enum.TryParse(rule.Operator, out nestedOperator) &&
+                    NestedOperators.Contains(nestedOperator) &&
+                    rule.Rules != null &&
+                    rule.Rules.Any()
+                       ? Build<T>(rule.Rules, parameterExpression, nestedOperator)
+                       : BuildExpression<T>(rule, parameterExpression);
+        }
+
+        public static Expression Build<T>(IEnumerable<Rule> rules, ParameterExpression parameterExpression, ExpressionType operation)
+        {
+            var expressions = rules.Select(r => Build<T>(r, parameterExpression));
+
+            return Build(expressions, operation);
+        }
+
+
+
+        private static Expression Build(IEnumerable<Expression> expressions, ExpressionType operationType)
+        {
+            Func<Expression, Expression, Expression> expressionAggregateMethod;
+            switch (operationType)
+            {
+                case ExpressionType.Or:
+                    expressionAggregateMethod = Expression.Or;
+                    break;
+                case ExpressionType.OrElse:
+                    expressionAggregateMethod = Expression.OrElse;
+                    break;
+                case ExpressionType.AndAlso:
+                    expressionAggregateMethod = Expression.AndAlso;
+                    break;
+                default:
+                    expressionAggregateMethod = Expression.And;
+                    break;
+            }
+
+            return BuildExpression(expressions, expressionAggregateMethod);
+        }
+
+        private static Expression BuildExpression(IEnumerable<Expression> expressions, Func<Expression, Expression, Expression> expressionAggregateMethod)
+        {
+            return expressions.Aggregate<Expression, Expression>(null,
+                (current, expression) => current == null
+                    ? expression
+                    : expressionAggregateMethod(current, expression)
+            );
+        }
+
+        private static Expression BuildExpression<T>(Rule rule, Expression expression)
+        {
+            Expression propExpression;
+            Type propType;
+            if (string.IsNullOrEmpty(rule.MemberName)) //check is against the object itself
+            {
+                propExpression = expression;
+                propType = propExpression.Type;
+            }
+            else if (rule.MemberName.Contains('.')) //Child property
+            {
+                var childProperties = rule.MemberName.Split('.');
+                var property = typeof(T).GetProperty(childProperties[0]);
+                // not being used?
+                // ParameterExpression paramExp = Expression.Parameter(typeof(T), "SomeObject");
+
+                propExpression = Expression.PropertyOrField(expression, childProperties[0]);
+                for (var i = 1; i < childProperties.Length; i++)
+                {
+                    // not being used?
+                    // PropertyInfo orig = property;
+                    if (property == null) continue;
+                    property = property.PropertyType.GetProperty(childProperties[i]);
+                    if (property == null) continue;
+                    propExpression = Expression.PropertyOrField(propExpression, childProperties[i]);
+                }
+                propType = propExpression.Type;
+            }
+            else //Property
+            {
+                propExpression = Expression.PropertyOrField(expression, rule.MemberName);
+                propType = propExpression.Type;
+            }
+
+            ExpressionType tBinary;
+            // is the operator a known .NET operator?
+            if (Enum.TryParse(rule.Operator, out tBinary))
+            {
+                var right = StringToExpression(rule.TargetValue, propType);
+                return Expression.MakeBinary(tBinary, propExpression, right);
+            }
+            if (rule.Operator == StrIsMatch)
+            {
+                return Expression.Call(
+                    typeof(Regex).GetMethod(StrIsMatch,
+                        new[]
+                        {
+                            typeof (string),
+                            typeof (string),
+                            typeof (RegexOptions)
+                        }
+                    ),
+                    propExpression,
+                    Expression.Constant(rule.TargetValue, typeof(string)),
+                    Expression.Constant(RegexOptions.IgnoreCase, typeof(RegexOptions))
+                    );
+            }
+            //Invoke a method on the Property
+            var inputs = rule.Inputs.Select(x => x.GetType()).ToArray();
+            var methodInfo = propType.GetMethod(rule.Operator, inputs);
+            if (!methodInfo.IsGenericMethod)
+                inputs = null; //Only pass in type information to a Generic Method
+            var expressions = rule.Inputs.Select(Expression.Constant).ToArray();
+            return Expression.Call(propExpression, rule.Operator, inputs, expressions);
+        }
+
+        private static Expression StringToExpression(string value, Type propType)
+        {
+            return value.ToLower() == StrNull
+                ? Expression.Constant(null)
+                : Expression.Constant(propType.IsEnum
+                    ? Enum.Parse(propType, value)
+                    : Convert.ChangeType(value, propType));
+        }
+    }
+}

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -157,9 +157,11 @@ namespace MicroRuleEngine
 
         private static Expression StringToExpression(string value, Type propType)
         {
-            return Expression.Constant(value.ToLower() == "null" 
-                ? null 
-                : Convert.ChangeType(value, propType));
+            return value.ToLower() == "null"
+                       ? Expression.Constant(null)
+                       : Expression.Constant(propType.IsEnum
+                                                 ? Enum.Parse(propType, value)
+                                                 : Convert.ChangeType(value, propType));
         }
     }
 

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -58,7 +58,7 @@ namespace MicroRuleEngine
             return BinaryExpression(expressions, operation);
         }
 
-        private static Expression BinaryExpression(IList<Expression> expressions, ExpressionType operationType)
+        private static Expression BinaryExpression(IEnumerable<Expression> expressions, ExpressionType operationType)
         {
             Func<Expression, Expression, Expression> methodExp;
             switch (operationType)
@@ -80,27 +80,22 @@ namespace MicroRuleEngine
             return BuildExpression(expressions, methodExp);
         }
 
-        private static Expression BuildExpression(IList<Expression> expressions,
+        private static Expression BuildExpression(IEnumerable<Expression> expressions,
                                                   Func<Expression, Expression, Expression> method)
         {
-            if (expressions.Count == 1)
-                return expressions[0];
-
-            Expression exp = method(expressions[0], expressions[1]);
-
-            for (int i = 2; expressions.Count > i; i++)
-            {
-                exp = method(exp, expressions[i]);
-            }
-            return exp;
+            return expressions.Aggregate<Expression, Expression>(
+                null, (current, expression) => current == null
+                                                   ? expression
+                                                   : method(current,
+                                                            expression));
         }
 
-        private Expression AndExpressions(IList<Expression> expressions)
+        private Expression AndExpressions(IEnumerable<Expression> expressions)
         {
             return BuildExpression(expressions, Expression.And);
         }
 
-        private Expression OrExpressions(IList<Expression> expressions)
+        private Expression OrExpressions(IEnumerable<Expression> expressions)
         {
             return BuildExpression(expressions, Expression.Or);
         }

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -1,188 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
-using System.Text.RegularExpressions;
+using System;
 
 namespace MicroRuleEngine
 {
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// for backword compatibility
+    /// </remarks>
     public class MRE
     {
-        public static MRE Instance
+        public static MRE Instance { get; } = new MRE();
+
+        public Func<T, bool> Compile<T>(Rule rule)
         {
-            get { return _instance ?? (_instance = new MRE()); }
-        }
-
-        public bool PassesRules<T>(IList<Rule> rules, T toInspect)
-        {
-            return Compile<T>(rules).Invoke(toInspect);
-        }
-
-        public Func<T, bool> Compile<T>(Rule r)
-        {
-            ParameterExpression paramUser = Expression.Parameter(typeof(T));
-            Expression expr = GetExpressionForRule<T>(r, paramUser);
-
-            return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
-        }
-
-        public Func<T, bool> Compile<T>(IList<Rule> rules)
-        {
-            ParameterExpression paramUser = Expression.Parameter(typeof(T));
-            Expression expr = BuildNestedExpression<T>(rules, paramUser, ExpressionType.And);
-            return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
-        }
-
-        private MRE()
-        { }
-
-        private static MRE _instance;
-
-        private const string StrIsMatch = "IsMatch";
-
-        private const string StrNull = "null";
-
-        private readonly ExpressionType[] _nestedOperators = new[]
-                                                                     {
-                                                                         ExpressionType.And,
-                                                                         ExpressionType.AndAlso,
-                                                                         ExpressionType.Or,
-                                                                         ExpressionType.OrElse
-                                                                     };
-
-        private Expression GetExpressionForRule<T>(Rule r, ParameterExpression param)
-        {
-            ExpressionType nestedOperator;
-            return Enum.TryParse(r.Operator, out nestedOperator) && _nestedOperators.Contains(nestedOperator) &&
-                   r.Rules != null && r.Rules.Any()
-                       ? BuildNestedExpression<T>(r.Rules, param, nestedOperator)
-                       : BuildExpr<T>(r, param);
-        }
-
-        private Expression BuildNestedExpression<T>(IEnumerable<Rule> rules,
-                                                    ParameterExpression param,
-                                                    ExpressionType operation)
-        {
-            List<Expression> expressions = rules.Select(r => GetExpressionForRule<T>(r, param)).ToList();
-
-            return BinaryExpression(expressions, operation);
-        }
-
-        private static Expression BinaryExpression(IEnumerable<Expression> expressions, ExpressionType operationType)
-        {
-            Func<Expression, Expression, Expression> methodExp;
-            switch (operationType)
-            {
-                case ExpressionType.Or:
-                    methodExp = Expression.Or;
-                    break;
-                case ExpressionType.OrElse:
-                    methodExp = Expression.OrElse;
-                    break;
-                case ExpressionType.AndAlso:
-                    methodExp = Expression.AndAlso;
-                    break;
-                default:
-                    methodExp = Expression.And;
-                    break;
-            }
-
-            return BuildExpression(expressions, methodExp);
-        }
-
-        private static Expression BuildExpression(IEnumerable<Expression> expressions,
-                                                  Func<Expression, Expression, Expression> method)
-        {
-            return expressions.Aggregate<Expression, Expression>(
-                null, (current, expression) => current == null
-                                                   ? expression
-                                                   : method(current,
-                                                            expression));
-        }
-
-        private Expression AndExpressions(IEnumerable<Expression> expressions)
-        {
-            return BuildExpression(expressions, Expression.And);
-        }
-
-        private Expression OrExpressions(IEnumerable<Expression> expressions)
-        {
-            return BuildExpression(expressions, Expression.Or);
-        }
-
-        private static Expression BuildExpr<T>(Rule r, Expression param)
-        {
-            Expression propExpression;
-            Type propType;
-
-            ExpressionType tBinary;
-            if (string.IsNullOrEmpty(r.MemberName)) //check is against the object itself
-            {
-                propExpression = param;
-                propType = propExpression.Type;
-            }
-            else if (r.MemberName.Contains('.')) //Child property
-            {
-                String[] childProperties = r.MemberName.Split('.');
-                PropertyInfo property = typeof(T).GetProperty(childProperties[0]);
-                // not being used?
-                // ParameterExpression paramExp = Expression.Parameter(typeof(T), "SomeObject");
-
-                propExpression = Expression.PropertyOrField(param, childProperties[0]);
-                for (int i = 1; i < childProperties.Length; i++)
-                {
-                    // not being used?
-                    // PropertyInfo orig = property;
-                    property = property.PropertyType.GetProperty(childProperties[i]);
-                    if (property != null)
-                        propExpression = Expression.PropertyOrField(propExpression, childProperties[i]);
-                }
-                propType = propExpression.Type;
-            }
-            else //Property
-            {
-                propExpression = Expression.PropertyOrField(param, r.MemberName);
-                propType = propExpression.Type;
-            }
-
-            // is the operator a known .NET operator?
-            if (Enum.TryParse(r.Operator, out tBinary))
-            {
-                Expression right = StringToExpression(r.TargetValue, propType);
-                return Expression.MakeBinary(tBinary, propExpression, right);
-            }
-            if (r.Operator == StrIsMatch)
-            {
-                return Expression.Call(
-                    typeof(Regex).GetMethod(StrIsMatch,
-                                             new[]
-                                                     {
-                                                         typeof (string),
-                                                         typeof (string),
-                                                         typeof (RegexOptions)
-                                                     }),
-                    propExpression,
-                    Expression.Constant(r.TargetValue, typeof(string)),
-                    Expression.Constant(RegexOptions.IgnoreCase, typeof(RegexOptions))
-                    );
-            }
-            //Invoke a method on the Property
-            Type[] inputs = r.Inputs.Select(x => x.GetType()).ToArray();
-            MethodInfo methodInfo = propType.GetMethod(r.Operator, inputs);
-            if (!methodInfo.IsGenericMethod)
-                inputs = null; //Only pass in type information to a Generic Method
-            ConstantExpression[] expressions = r.Inputs.Select(Expression.Constant).ToArray();
-            return Expression.Call(propExpression, r.Operator, inputs, expressions);
-        }
-
-        private static Expression StringToExpression(string value, Type propType)
-        {
-            return value.ToLower() == StrNull
-                       ? Expression.Constant(null)
-                       : Expression.Constant(propType.IsEnum
-                                                 ? Enum.Parse(propType, value)
-                                                 : Convert.ChangeType(value, propType));
+            return RuleCompiler.Compile<T>(rule);
         }
     }
 }

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -19,12 +19,12 @@ namespace MicroRuleEngine
 
         public bool PassesRules<T>(IList<Rule> rules, T toInspect)
         {
-            return CompileRules<T>(rules).Invoke(toInspect);
+            return Evaluate<T>(rules).Invoke(toInspect);
         }
 
-        public Func<T, bool> CompileRule<T>(Rule r)
+        public Func<T, bool> Evaluate<T>(Rule r)
         {
-            ParameterExpression paramUser = Expression.Parameter(typeof(T));
+            ParameterExpression paramUser = Expression.Parameter(typeof (T));
             Expression expr = GetExpressionForRule<T>(r, paramUser);
 
             return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
@@ -39,14 +39,15 @@ namespace MicroRuleEngine
                        : BuildExpr<T>(r, param);
         }
 
-        public Func<T, bool> CompileRules<T>(IList<Rule> rules)
+        public Func<T, bool> Evaluate<T>(IList<Rule> rules)
         {
-            ParameterExpression paramUser = Expression.Parameter(typeof(T));
+            ParameterExpression paramUser = Expression.Parameter(typeof (T));
             Expression expr = BuildNestedExpression<T>(rules, paramUser, ExpressionType.And);
             return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
         }
 
-        private Expression BuildNestedExpression<T>(IEnumerable<Rule> rules, ParameterExpression param,
+        private Expression BuildNestedExpression<T>(IEnumerable<Rule> rules,
+                                                    ParameterExpression param,
                                                     ExpressionType operation)
         {
             List<Expression> expressions = rules.Select(r => GetExpressionForRule<T>(r, param)).ToList();
@@ -76,7 +77,8 @@ namespace MicroRuleEngine
             return BuildExpression(expressions, methodExp);
         }
 
-        private static Expression BuildExpression(IList<Expression> expressions, Func<Expression, Expression, Expression> method)
+        private static Expression BuildExpression(IList<Expression> expressions,
+                                                  Func<Expression, Expression, Expression> method)
         {
             if (expressions.Count == 1)
                 return expressions[0];
@@ -114,8 +116,8 @@ namespace MicroRuleEngine
             else if (r.MemberName.Contains('.')) //Child property
             {
                 String[] childProperties = r.MemberName.Split('.');
-                PropertyInfo property = typeof(T).GetProperty(childProperties[0]);
-                ParameterExpression paramExp = Expression.Parameter(typeof(T), "SomeObject");
+                PropertyInfo property = typeof (T).GetProperty(childProperties[0]);
+                ParameterExpression paramExp = Expression.Parameter(typeof (T), "SomeObject");
 
                 propExpression = Expression.PropertyOrField(param, childProperties[0]);
                 for (int i = 1; i < childProperties.Length; i++)
@@ -142,7 +144,7 @@ namespace MicroRuleEngine
             if (r.Operator == "IsMatch")
             {
                 return Expression.Call(
-                    typeof(Regex).GetMethod("IsMatch",
+                    typeof (Regex).GetMethod("IsMatch",
                                              new[]
                                                  {
                                                      typeof (string),
@@ -150,8 +152,8 @@ namespace MicroRuleEngine
                                                      typeof (RegexOptions)
                                                  }),
                     propExpression,
-                    Expression.Constant(r.TargetValue, typeof(string)),
-                    Expression.Constant(RegexOptions.IgnoreCase, typeof(RegexOptions))
+                    Expression.Constant(r.TargetValue, typeof (string)),
+                    Expression.Constant(RegexOptions.IgnoreCase, typeof (RegexOptions))
                     );
             }
             //Invoke a method on the Property

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -9,16 +9,10 @@ namespace MicroRuleEngine
 {
     public class MRE
     {
-        private const string StrIsMatch = "IsMatch";
-        private const string StrNull = "null";
-
-        private readonly ExpressionType[] _nestedOperators = new[]
-                                                                 {
-                                                                     ExpressionType.And,
-                                                                     ExpressionType.AndAlso,
-                                                                     ExpressionType.Or,
-                                                                     ExpressionType.OrElse
-                                                                 };
+        public static MRE Instance
+        {
+            get { return _instance ?? (_instance = new MRE()); }
+        }
 
         public bool PassesRules<T>(IList<Rule> rules, T toInspect)
         {
@@ -39,6 +33,23 @@ namespace MicroRuleEngine
             Expression expr = BuildNestedExpression<T>(rules, paramUser, ExpressionType.And);
             return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
         }
+
+        private MRE()
+        { }
+
+        private static MRE _instance;
+
+        private const string StrIsMatch = "IsMatch";
+
+        private const string StrNull = "null";
+
+        private readonly ExpressionType[] _nestedOperators = new[]
+                                                                     {
+                                                                         ExpressionType.And,
+                                                                         ExpressionType.AndAlso,
+                                                                         ExpressionType.Or,
+                                                                         ExpressionType.OrElse
+                                                                     };
 
         private Expression GetExpressionForRule<T>(Rule r, ParameterExpression param)
         {
@@ -146,11 +157,11 @@ namespace MicroRuleEngine
                 return Expression.Call(
                     typeof(Regex).GetMethod(StrIsMatch,
                                              new[]
-                                                 {
-                                                     typeof (string),
-                                                     typeof (string),
-                                                     typeof (RegexOptions)
-                                                 }),
+                                                     {
+                                                         typeof (string),
+                                                         typeof (string),
+                                                         typeof (RegexOptions)
+                                                     }),
                     propExpression,
                     Expression.Constant(r.TargetValue, typeof(string)),
                     Expression.Constant(RegexOptions.IgnoreCase, typeof(RegexOptions))

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -22,10 +22,10 @@ namespace MicroRuleEngine
 
         public bool PassesRules<T>(IList<Rule> rules, T toInspect)
         {
-            return Evaluate<T>(rules).Invoke(toInspect);
+            return Compile<T>(rules).Invoke(toInspect);
         }
 
-        public Func<T, bool> Evaluate<T>(Rule r)
+        public Func<T, bool> Compile<T>(Rule r)
         {
             ParameterExpression paramUser = Expression.Parameter(typeof(T));
             Expression expr = GetExpressionForRule<T>(r, paramUser);
@@ -33,7 +33,7 @@ namespace MicroRuleEngine
             return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
         }
 
-        public Func<T, bool> Evaluate<T>(IList<Rule> rules)
+        public Func<T, bool> Compile<T>(IList<Rule> rules)
         {
             ParameterExpression paramUser = Expression.Parameter(typeof(T));
             Expression expr = BuildNestedExpression<T>(rules, paramUser, ExpressionType.And);

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -49,8 +49,7 @@ namespace MicroRuleEngine
         {
             List<Expression> expressions = rules.Select(r => GetExpressionForRule<T>(r, param)).ToList();
 
-            Expression expr = BinaryExpression(expressions, operation);
-            return expr;
+            return BinaryExpression(expressions, operation);
         }
 
         static Expression BinaryExpression(IList<Expression> expressions, ExpressionType operationType)

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -8,7 +8,13 @@ namespace MicroRuleEngine
 {
     public class MRE
     {
-        private readonly ExpressionType[] _nestedOperators = new[] { ExpressionType.And, ExpressionType.AndAlso, ExpressionType.Or, ExpressionType.OrElse };
+        private readonly ExpressionType[] _nestedOperators = new[]
+                                                                 {
+                                                                     ExpressionType.And,
+                                                                     ExpressionType.AndAlso,
+                                                                     ExpressionType.Or,
+                                                                     ExpressionType.OrElse
+                                                                 };
 
         public bool PassesRules<T>(IList<Rule> rules, T toInspect)
         {
@@ -49,7 +55,7 @@ namespace MicroRuleEngine
 
         static Expression BinaryExpression(IList<Expression> expressions, ExpressionType operationType)
         {
-            Func<Expression, Expression, Expression> methodExp = Expression.And;
+            Func<Expression, Expression, Expression> methodExp;
             switch (operationType)
             {
                 case ExpressionType.Or:
@@ -60,6 +66,9 @@ namespace MicroRuleEngine
                     break;
                 case ExpressionType.AndAlso:
                     methodExp = Expression.AndAlso;
+                    break;
+                default:
+                    methodExp = Expression.And;
                     break;
             }
 
@@ -103,12 +112,12 @@ namespace MicroRuleEngine
             Type propType = null;
 
             ExpressionType tBinary;
-            if (string.IsNullOrEmpty(r.MemberName))//check is against the object itself
+            if (string.IsNullOrEmpty(r.MemberName)) //check is against the object itself
             {
                 propExpression = param;
                 propType = propExpression.Type;
             }
-            else if (r.MemberName.Contains('.'))//Child property
+            else if (r.MemberName.Contains('.')) //Child property
             {
                 String[] childProperties = r.MemberName.Split('.');
                 var property = typeof(T).GetProperty(childProperties[0]);
@@ -124,7 +133,7 @@ namespace MicroRuleEngine
                 }
                 propType = propExpression.Type;
             }
-            else//Property
+            else //Property
             {
                 propExpression = Expression.PropertyOrField(param, r.MemberName);
                 propType = propExpression.Type;
@@ -140,7 +149,12 @@ namespace MicroRuleEngine
             {
                 return Expression.Call(
                     typeof(Regex).GetMethod("IsMatch",
-                                            new[] { typeof(string), typeof(string), typeof(RegexOptions) }),
+                                             new[]
+                                                 {
+                                                     typeof (string),
+                                                     typeof (string),
+                                                     typeof (RegexOptions)
+                                                 }),
                     propExpression,
                     Expression.Constant(r.TargetValue, typeof(string)),
                     Expression.Constant(RegexOptions.IgnoreCase, typeof(RegexOptions))
@@ -155,7 +169,7 @@ namespace MicroRuleEngine
             return Expression.Call(propExpression, r.Operator, inputs, expressions);
         }
 
-        private static Expression StringToExpression(string value, Type propType)
+        static Expression StringToExpression(string value, Type propType)
         {
             return value.ToLower() == "null"
                        ? Expression.Constant(null)

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -30,6 +30,13 @@ namespace MicroRuleEngine
             return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
         }
 
+        public Func<T, bool> Evaluate<T>(IList<Rule> rules)
+        {
+            ParameterExpression paramUser = Expression.Parameter(typeof (T));
+            Expression expr = BuildNestedExpression<T>(rules, paramUser, ExpressionType.And);
+            return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
+        }
+
         private Expression GetExpressionForRule<T>(Rule r, ParameterExpression param)
         {
             ExpressionType nestedOperator;
@@ -37,13 +44,6 @@ namespace MicroRuleEngine
                    r.Rules != null && r.Rules.Any()
                        ? BuildNestedExpression<T>(r.Rules, param, nestedOperator)
                        : BuildExpr<T>(r, param);
-        }
-
-        public Func<T, bool> Evaluate<T>(IList<Rule> rules)
-        {
-            ParameterExpression paramUser = Expression.Parameter(typeof (T));
-            Expression expr = BuildNestedExpression<T>(rules, paramUser, ExpressionType.And);
-            return Expression.Lambda<Func<T, bool>>(expr, paramUser).Compile();
         }
 
         private Expression BuildNestedExpression<T>(IEnumerable<Rule> rules,

--- a/MicroRuleEngine/MicroRuleEngine.csproj
+++ b/MicroRuleEngine/MicroRuleEngine.csproj
@@ -41,6 +41,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MRE.cs" />
+    <Compile Include="RuleCompiler.cs" />
+    <Compile Include="ExpressionBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rule.cs" />
     <Compile Include="RuleValue.cs" />

--- a/MicroRuleEngine/MicroRuleEngine.csproj
+++ b/MicroRuleEngine/MicroRuleEngine.csproj
@@ -42,6 +42,9 @@
   <ItemGroup>
     <Compile Include="MRE.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rule.cs" />
+    <Compile Include="RuleValue.cs" />
+    <Compile Include="RuleValueString.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MicroRuleEngine/Properties/AssemblyInfo.cs
+++ b/MicroRuleEngine/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/MicroRuleEngine/Properties/AssemblyInfo.cs
+++ b/MicroRuleEngine/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("MicroRuleEngine")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("The Micro Rule Engine is a small(As in about 200 lines) Rule Engine that allows you to create Business rules that are not hard coded.  Under the hood MRE creates a Linq Expression tree and compies a rule into an anonymous method i.e. Func<T,bool>")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("MicroRuleEngine")]
-[assembly: AssemblyCopyright("Copyright ©  2012")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.4.0")]
+[assembly: AssemblyFileVersion("1.0.4.0")]

--- a/MicroRuleEngine/Rule.cs
+++ b/MicroRuleEngine/Rule.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace MicroRuleEngine
+{
+    public class Rule
+    {
+        public Rule()
+        {
+            Inputs = new List<object>();
+        }
+
+        public string MemberName { get; set; }
+        public string Operator { get; set; }
+        public string TargetValue { get; set; }
+        public List<Rule> Rules { get; set; }
+        public List<object> Inputs { get; set; }
+    }
+}

--- a/MicroRuleEngine/Rule.cs
+++ b/MicroRuleEngine/Rule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace MicroRuleEngine
 {
@@ -6,13 +7,13 @@ namespace MicroRuleEngine
     {
         public Rule()
         {
-            Inputs = new List<object>();
+            Inputs = Enumerable.Empty<object>();
         }
 
         public string MemberName { get; set; }
         public string Operator { get; set; }
         public string TargetValue { get; set; }
-        public List<Rule> Rules { get; set; }
-        public List<object> Inputs { get; set; }
+        public IEnumerable<Rule> Rules { get; set; }
+        public IEnumerable<object> Inputs { get; set; }
     }
 }

--- a/MicroRuleEngine/RuleCompiler.cs
+++ b/MicroRuleEngine/RuleCompiler.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace MicroRuleEngine
+{
+    public static class RuleCompiler
+    {
+        public static Func<T, bool> Compile<T>(Rule rule)
+        {
+            var expressionParameter = Expression.Parameter(typeof(T));
+            var expression = ExpressionBuilder.Build<T>(rule, expressionParameter);
+
+            return Expression.Lambda<Func<T, bool>>(expression, expressionParameter).Compile();
+        }
+
+        public static Func<T, bool> Compile<T>(IEnumerable<Rule> rules)
+        {
+            var expressionParameter = Expression.Parameter(typeof(T));
+            var expression = ExpressionBuilder.Build<T>(rules, expressionParameter, ExpressionType.And);
+            return Expression.Lambda<Func<T, bool>>(expression, expressionParameter).Compile();
+        }
+    }
+}

--- a/MicroRuleEngine/RuleValue.cs
+++ b/MicroRuleEngine/RuleValue.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace MicroRuleEngine
+{
+    public class RuleValue<T>
+    {
+        public T Value { get; set; }
+        public List<Rule> Rules { get; set; }
+    }
+}

--- a/MicroRuleEngine/RuleValue.cs
+++ b/MicroRuleEngine/RuleValue.cs
@@ -5,6 +5,6 @@ namespace MicroRuleEngine
     public class RuleValue<T>
     {
         public T Value { get; set; }
-        public List<Rule> Rules { get; set; }
+        public IEnumerable<Rule> Rules { get; set; }
     }
 }

--- a/MicroRuleEngine/RuleValueString.cs
+++ b/MicroRuleEngine/RuleValueString.cs
@@ -1,0 +1,6 @@
+﻿namespace MicroRuleEngine
+{
+    public class RuleValueString : RuleValue<string>
+    {
+    }
+}


### PR DESCRIPTION
Renamed nestedOperators to _\* in order to follow private variable standards, also made it readonly as its value never changes

Made possible methods static

Used base types where possible

Using LINQ expression instead of a foreach loop

Simplified switch case in BinaryExpression

Simplified if-elseif-else since it was using returns

Simplified StringToExpression, it now is a single line that doesn't need a temporary variable

And most important - All unit tests pass
