### PR TITLE
Additional functionality for IsInInput and multi targeting

### DIFF
--- a/MicroRuleEngine.Core.Tests/InMemoryEntityFrameworkTests.cs
+++ b/MicroRuleEngine.Core.Tests/InMemoryEntityFrameworkTests.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) 2019 Jeremy Oursler All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MicroRuleEngine.Tests
+{
+    [TestClass]
+    public class InMemoryEntityFrameworkTests
+    {
+        private DbContextOptions<TestDbContext> options;
+
+        [TestMethod]
+        public void CheckSetup()
+        {
+            using (var context = new TestDbContext(options))
+            {
+                var count = context.Students.Count();
+
+                Assert.AreEqual(8,
+                                count);
+            }
+        }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            options = new DbContextOptionsBuilder<TestDbContext>()
+                      .UseInMemoryDatabase(Guid.NewGuid()
+                                               .ToString())
+                      .Options;
+
+            using (var context = new TestDbContext(options))
+            {
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "Bob",
+                                         LastName  = "Smith",
+                                         Gpa       = 2.0m
+                                     });
+
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "John",
+                                         LastName  = "Smith",
+                                         Gpa       = 3.5m
+                                     });
+
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "Bob",
+                                         LastName  = "Jones",
+                                         Gpa       = 3.0m
+                                     });
+
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "John",
+                                         LastName  = "Jones",
+                                         Gpa       = 4.0m
+                                     });
+
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "Jane",
+                                         LastName  = "Smith",
+                                         Gpa       = 3.75m
+                                     });
+
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "Sally",
+                                         LastName  = "Smith",
+                                         Gpa       = 1.0m
+                                     });
+
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "Jane",
+                                         LastName  = "Jones",
+                                         Gpa       = 1.5m
+                                     });
+
+                context.Students.Add(new Student
+                                     {
+                                         FirstName = "Sally",
+                                         LastName  = "Jones",
+                                         Gpa       = 2.5m
+                                     });
+
+                context.SaveChanges();
+            }
+        }
+
+        [TestMethod]
+        public void MoreComplicated()
+        {
+            var rule =
+                new Rule
+                {
+                    Operator = "OrElse",
+                    Rules = new List<Rule>
+                            {
+                                new Rule
+                                {
+                                    MemberName  = "FirstName",
+                                    Operator    = "Equal",
+                                    TargetValue = "Sally"
+                                },
+                                new Rule
+                                {
+                                    MemberName  = "FirstName",
+                                    Operator    = "Equal",
+                                    TargetValue = "Jane"
+                                }
+                            }
+                };
+
+            var expression = MRE.ToExpression<Student>(rule, false);
+
+            using (var context = new TestDbContext(options))
+            {
+                var count = context.Students.Where(expression)
+                                   .Count();
+
+                Assert.AreEqual(4,
+                                count);
+            }
+        }
+
+        [TestMethod]
+        public void ReallyComplicated()
+        {
+            var rule =
+                new Rule
+                {
+                    Operator = "AndAlso",
+                    Rules = new List<Rule>
+                            {
+                                new Rule
+                                {
+                                    Operator = "OrElse",
+                                    Rules = new List<Rule>
+                                            {
+                                                new Rule
+                                                {
+                                                    MemberName  = "FirstName",
+                                                    Operator    = "Equal",
+                                                    TargetValue = "Sally"
+                                                },
+                                                new Rule
+                                                {
+                                                    MemberName  = "FirstName",
+                                                    Operator    = "Equal",
+                                                    TargetValue = "Jane"
+                                                }
+                                            }
+                                },
+                                new Rule
+                                {
+                                    MemberName  = "Gpa",
+                                    Operator    = "GreaterThan",
+                                    TargetValue = "2.0"
+                                }
+                            }
+                };
+
+            var expression = MRE.ToExpression<Student>(rule, false);
+
+            using (var context = new TestDbContext(options))
+            {
+                var count = context.Students.Where(expression)
+                                   .Count();
+
+                Assert.AreEqual(2,
+                                count);
+            }
+        }
+
+        [TestMethod]
+        public void SimpleRule()
+        {
+            var rule = new Rule
+                       {
+                           MemberName  = "FirstName",
+                           Operator    = "Equal",
+                           TargetValue = "Sally"
+                       };
+
+            var expression = MRE.ToExpression<Student>(rule, false);
+
+            using (var context = new TestDbContext(options))
+            {
+                var count = context.Students.Where(expression)
+                                   .Count();
+
+                Assert.AreEqual(2,
+                                count);
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NotImplementedException))]
+        public void SimpleRule_IncludeTryCatch()
+        {
+            var rule = new Rule
+                       {
+                           MemberName  = "FirstName",
+                           Operator    = "Equal",
+                           TargetValue = "Sally"
+                       };
+
+            var expression = MRE.ToExpression<Student>(rule, true);
+
+            using (var context = new TestDbContext(options))
+            {
+                var count = context.Students.Where(expression)
+                                   .Count();
+
+                Assert.AreEqual(2,
+                                count);
+            }
+        }
+    }
+
+    public class Student
+    {
+        [MaxLength(32)]
+        public string FirstName { get; set; }
+
+        public decimal Gpa { get; set; }
+
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [MaxLength(32)]
+        public string LastName { get; set; }
+    }
+
+    public class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Student> Students { get; set; }
+    }
+}

--- a/MicroRuleEngine.Core.Tests/MicroRuleEngine.Core.Tests.csproj
+++ b/MicroRuleEngine.Core.Tests/MicroRuleEngine.Core.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />

--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -212,6 +212,106 @@ namespace MicroRuleEngine.Tests
             Assert.IsFalse(passes);
         }
 
+        [TestMethod]
+        public void BareString()
+        {
+            var rule = new Rule()
+            {
+                Operator = "StartsWith",
+                Inputs = new[] { "FDX" }
+            };
+
+            var engine = new MRE();
+            var childPropCheck = engine.CompileRule<string>(rule);
+            var passes = childPropCheck("FDX 123456");
+            Assert.IsTrue(passes);
+
+
+            passes = childPropCheck("BOB 123456");
+            Assert.IsFalse(passes);
+        }
+
+        [TestMethod]
+        public void IsInInput_SingleValue()
+        {
+            var value = "hello";
+
+            var rule = new Rule()
+            {
+                Operator = "IsInInput",
+                Inputs = new List<string> { "hello" }
+            };
+
+            var mre = new MRE();
+
+            var ruleFunc = mre.CompileRule<string>(rule);
+
+            Assert.IsTrue(ruleFunc(value));
+        }
+
+        [TestMethod]
+        public void IsInInput_MultiValue()
+        {
+            var value = "hello";
+
+            var rule = new Rule()
+            {
+                Operator = "IsInInput",
+                Inputs = new List<string> { "hello", "World" }
+            };
+
+            var mre = new MRE();
+
+            var ruleFunc = mre.CompileRule<string>(rule);
+
+            Assert.IsTrue(ruleFunc(value));
+        }
+
+        [TestMethod]
+        public void IsInInput_NoExactMatch()
+        {
+            var value = "world";
+
+            var rule = new Rule()
+            {
+                Operator = "IsInInput",
+                Inputs = new List<string> { "hello", "World" }
+            };
+
+            var mre = new MRE();
+
+            var ruleFunc = mre.CompileRule<string>(rule);
+
+            Assert.IsFalse(ruleFunc(value));
+        }
+
+        [TestMethod]
+        public void MemberEqualsMember()
+        {
+            var testObj = new MemberOperaterMemberTestObject()
+            {
+                Source = "bob",
+                Target = "bob"
+            };
+
+            var rule = new Rule
+            {
+                MemberName = "Source",
+                Operator = "Equal",
+                TargetValue = "*.Target"
+            };
+
+            var mre = new MRE();
+
+            var func = mre.CompileRule<MemberOperaterMemberTestObject>(rule);
+
+            Assert.IsTrue(func(testObj));
+
+            testObj.Target = "notBob";
+
+            Assert.IsFalse(func(testObj));
+        }
+
         public static Order GetOrder()
         {
             Order order = new Order()

--- a/MicroRuleEngine.Tests/MicroRuleEngine.Tests.csproj
+++ b/MicroRuleEngine.Tests/MicroRuleEngine.Tests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="ExceptionTests.cs" />
     <Compile Include="IsTypeTests.cs" />
+    <Compile Include="Models\MemberOperaterMemberTestObject.cs" />
     <Compile Include="NewAPI.cs" />
     <Compile Include="Models\Order.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MicroRuleEngine.Tests/Models/MemberOperaterMemberTestObject.cs
+++ b/MicroRuleEngine.Tests/Models/MemberOperaterMemberTestObject.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MicroRuleEngine.Tests.Models
+{
+    class MemberOperaterMemberTestObject
+    {
+        public string Source { get; set; }
+        public string Target { get; set; }
+    }
+}

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -19,6 +20,9 @@ namespace MicroRuleEngine
 
         private static readonly Lazy<MethodInfo> _miGetItem = new Lazy<MethodInfo>(() =>
             typeof(System.Data.DataRow).GetMethod("get_Item", new Type[] { typeof(string) }));
+
+        private static readonly Lazy<MethodInfo> _miListContains = new Lazy<MethodInfo>(() =>
+            typeof(IList).GetMethod("Contains", new[] { typeof(object) }));
 
         private static readonly Tuple<string, Lazy<MethodInfo>>[] _enumrMethodsByName =
             new Tuple<string, Lazy<MethodInfo>>[]
@@ -322,6 +326,10 @@ namespace MicroRuleEngine
                         propExpression,
                         Expression.MakeMemberAccess(null, typeof(Placeholder).GetField("Decimal"))
                     );
+                case "IsInInput":
+                    return Expression.Call(Expression.Constant(rule.Inputs.ToList()),
+                                           _miListContains.Value,
+                                           propExpression);
                 default:
                     break;
             }
@@ -635,7 +643,8 @@ namespace MicroRuleEngine
                     mreOperator.IsInteger.ToString("g"),
                     mreOperator.IsSingle.ToString("g"),
                     mreOperator.IsDouble.ToString("g"),
-                    mreOperator.IsDecimal.ToString("g")
+                    mreOperator.IsDecimal.ToString("g"),
+                    mreOperator.IsInInput.ToString("g"),
                 };
             public static List<Operator> Operators(Type type, bool addLogicOperators = false, bool noOverloads = true)
             {
@@ -944,7 +953,11 @@ namespace MicroRuleEngine
         /// <summary>
         /// Checks that a value can be 'TryParsed' to a Decimal
         /// </summary>
-        IsDecimal = 104
+        IsDecimal = 104,
+        /// <summary>
+        /// Checks if the value of the property is in the input list
+        /// </summary>
+        IsInInput = 105
     }
 
 

--- a/MicroRuleEngine/MicroRuleEngine.csproj
+++ b/MicroRuleEngine/MicroRuleEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net40;net452;net461;netstandard2.0; netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
   </PropertyGroup>


### PR DESCRIPTION
Added multitargeting from .net framework 4.0 through .net core 3.1
Added IsInInput operator to enable Input.Contains(Property) rules
Added additional example usage to cover functionality that exists but was not tested
Added EF Core In Memory provider tests

I am supporting quite a few legacy projects as well as newer projects using .net framework 4.0, 4.5.2, and 4.6.1, .net standard 2.0, and .net core 2.1 and 3.1 (migration would be better but finding time for regression tests causes issues).  To that end the MRE.dll project has Target Frameworks updated to include the various versions and should now support .net framework 4.0 and on

Added the `IsInInput` is for rules that test `new []{"option1","option2","option3"}.Contains(obj.prop)`

Added example usage for `obj.prop1 = obj.prop2` (it existed but was hard to find)

Added some tests I had written for EF Core using Microsoft.EntityFrameworkCore.InMemory as the provider.
