### PR TITLE
Compatibility w/ IConfiguration

### DIFF
--- a/MicroRuleEngine.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Tests/ExampleUsage.cs
@@ -239,7 +239,7 @@ namespace MicroRuleEngine.Tests
             var rule = new Rule()
             {
                 Operator = "IsInInput",
-                Inputs = new List<string> { "hello" }
+                Inputs = new List<object> { "hello" }
             };
 
             var mre = new MRE();
@@ -257,7 +257,7 @@ namespace MicroRuleEngine.Tests
             var rule = new Rule()
             {
                 Operator = "IsInInput",
-                Inputs = new List<string> { "hello", "World" }
+                Inputs = new List<object> { "hello", "World" }
             };
 
             var mre = new MRE();
@@ -275,7 +275,7 @@ namespace MicroRuleEngine.Tests
             var rule = new Rule()
             {
                 Operator = "IsInInput",
-                Inputs = new List<string> { "hello", "World" }
+                Inputs = new List<object> { "hello", "World" }
             };
 
             var mre = new MRE();

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -700,14 +700,13 @@ namespace MicroRuleEngine
     {
         public Rule()
         {
-            Inputs = Enumerable.Empty<object>();
         }
 
         [DataMember] public string MemberName { get; set; }
         [DataMember] public string Operator { get; set; }
         [DataMember] public object TargetValue { get; set; }
         [DataMember] public IList<Rule> Rules { get; set; }
-        [DataMember] public IEnumerable<object> Inputs { get; set; }
+        [DataMember] public IList<object> Inputs { get; set; }
 
 
         public static Rule operator |(Rule lhs, Rule rhs)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,59 @@ examples:
 
 How Can I Store Rules?
 ---------------------
+
+If using .NET Core it is possible to use the options pattern to directly load rules from the application JSON configuration into the rule class.
+
+AppSettings
+```JSON
+"Ruleset": {
+  "Operator": "Or",
+  "Rules": [
+    {
+      "MemberName": "Customer.FirstName",
+      "Operator": "Equal",
+      "TargetValue": "John"
+    },
+    {
+      "MemberName": "Customer.FirstName",
+      "Operator": "Equal",
+      "TargetValue": "Judy"
+    }
+  ]
+}
+```
+
+Startup
+```C#
+public void ConfigureServices(IServiceCollection services)
+{
+    services.Configure<Rule>(opt => Configuration.GetSection("Ruleset").Bind(opt));
+}
+```
+
+Controller
+```C#
+public class HomeController : Controller
+{
+    private Func<Order, bool> _compiledRule;
+
+    public HomeController(IOptions<Rule> ruleset)
+    {
+        _compiledRule = new MRE().CompileRule<Order>(ruleset.Value);
+    }
+
+    public IActionResult Index()
+    {
+        var order = this.GetOrder();
+
+        if (_compiledRule(order))
+            return View("SpecialOffers");
+        else
+            return View();
+    }
+}
+```
+
 The `Rule` Class is just a **POCO** so you can store your rules as serialized `XML`, `JSON`, etc.
 
 #### Forked many times and now updated to pull in a lot of the great work done by jamescurran, nazimkov and others that help improve the API


### PR DESCRIPTION
I had to tweak the rule class to change Inputs field from IEnumerable to IList for compatibility w/ [IConfiguration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/#bind-hierarchical-configuration-data-using-the-options-pattern).  I updated tests and also added section to README for details in use.