### PR TITLE
Fixes #31 

### DIFF
--- a/MicroRuleEngine.Core.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Core.Tests/ExampleUsage.cs
@@ -434,5 +434,66 @@ namespace MicroRuleEngine.Tests
 
             Assert.IsTrue(passes);
         }
+
+        [TestMethod]
+        public void SerializeThenDeserializeComplexRules()
+        {
+            
+
+
+            Order order = GetOrder();
+
+            var orderParent = new OrderParent() {PlacedOrder = order};
+
+
+            Rule rule = new Rule
+                        {
+                            Operator = "AndAlso",
+                            Rules = new List<Rule>
+                                    {
+
+                                        new Rule
+                                        {
+                                            MemberName = "PlacedOrder.Items",
+                                            EnumerableValueExpression = new Selector
+                                                                        {
+                                                                            Operator = "Count"
+                                                                        },
+                                            Operator    = "GreaterThan",
+                                            TargetValue = 3
+                                        },
+
+                                        new Rule
+                                        {
+                                            MemberName = "PlacedOrder.Items",
+                                            EnumerableValueExpression = new Selector
+                                                                        {
+                                                                            MemberName = "Cost",
+                                                                            Operator   = "Sum"
+                                                                        },
+                                            Operator    = "GreaterThan",
+                                            TargetValue = 5
+                                        }
+                                    }
+                        };
+
+            var jsonString = JsonConvert.SerializeObject(rule);
+
+            var deserializedRule = JsonConvert.DeserializeObject<Rule>(jsonString);
+
+
+
+            MRE  engine       = new MRE();
+            var  compiledRule = engine.CompileRule<OrderParent>(deserializedRule);
+            bool passes       = compiledRule(orderParent);
+            Assert.IsFalse(passes);
+
+            order.Items.Add(new Item());
+            order.Items.Add(new Item());
+
+            passes = compiledRule(orderParent);
+
+            Assert.IsTrue(passes);
+        }
     }
 }

--- a/MicroRuleEngine.Core.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Core.Tests/ExampleUsage.cs
@@ -245,6 +245,11 @@ namespace MicroRuleEngine.Tests
             Assert.IsFalse(passes);
         }
 
+        public class OrderParent
+        {
+            public Order PlacedOrder { get; set; }
+        }
+
         public static Order GetOrder()
         {
             Order order = new Order()
@@ -303,7 +308,7 @@ namespace MicroRuleEngine.Tests
                                                    Operator   = "StartsWith",
                                                    Inputs     = new []{"M"}
                                                },
-                            EnumerableVauleExpression = new Selector
+                            EnumerableValueExpression = new Selector
                                                         {
                                                             MemberName = "Cost",
                                                             Operator   = "Sum"
@@ -320,6 +325,72 @@ namespace MicroRuleEngine.Tests
             order.Items[0].Cost = 4m;
             passes              = compiledRule(order);
             Assert.IsFalse(passes);
+        }
+
+        [TestMethod]
+        public void CountAggregation()
+        {
+
+            Order order = GetOrder();
+
+            Rule rule = new Rule
+                        {
+                            MemberName = "Items",
+                            EnumerableValueExpression = new Selector
+                                                        {
+                                                            Operator   = "Count"
+                                                        },
+                            Operator    = "GreaterThan",
+                            TargetValue = 3
+                        };
+
+            MRE  engine       = new MRE();
+            var  compiledRule = engine.CompileRule<Order>(rule);
+            bool passes       = compiledRule(order);
+            Assert.IsFalse(passes);
+
+            order.Items.Add(new Item());
+            order.Items.Add(new Item());
+
+            passes = compiledRule(order);
+
+            Assert.IsTrue(passes);
+
+        }
+
+        [TestMethod]
+        public void EnumerableAggregationOnChild()
+        {
+            
+
+
+            Order order = GetOrder();
+
+            var orderParent = new OrderParent() {PlacedOrder = order};
+
+
+            Rule rule = new Rule
+                        {
+                            MemberName = "PlacedOrder.Items",
+                            EnumerableValueExpression = new Selector
+                                                        {
+                                                            Operator = "Count"
+                                                        },
+                            Operator    = "GreaterThan",
+                            TargetValue = 3
+                        };
+
+            MRE  engine       = new MRE();
+            var  compiledRule = engine.CompileRule<OrderParent>(rule);
+            bool passes       = compiledRule(orderParent);
+            Assert.IsFalse(passes);
+
+            order.Items.Add(new Item());
+            order.Items.Add(new Item());
+
+            passes = compiledRule(orderParent);
+
+            Assert.IsTrue(passes);
         }
     }
 }

--- a/MicroRuleEngine.Core.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Core.Tests/ExampleUsage.cs
@@ -278,5 +278,48 @@ namespace MicroRuleEngine.Tests
             };
             return order;
         }
+
+        [TestMethod]
+        public void EnumerableFilterAndAggregation()
+        {
+            
+
+
+            Order order = GetOrder();
+
+            if (order.Items.Where(x => x.ItemCode.StartsWith("M"))
+                     .Sum(x => x.Cost) > 6)
+            {
+
+            }
+
+
+            Rule rule = new Rule
+                        {
+                            MemberName = "Items",
+                            EnumerableFilter = new Rule
+                                               {
+                                                   MemberName = "ItemCode",
+                                                   Operator   = "StartsWith",
+                                                   Inputs     = new []{"M"}
+                                               },
+                            EnumerableVauleExpression = new Selector
+                                                        {
+                                                            MemberName = "Cost",
+                                                            Operator   = "Sum"
+                                                        },
+                            Operator    = "GreaterThan",
+                            TargetValue = 5
+                        };
+
+            MRE  engine       = new MRE();
+            var  compiledRule = engine.CompileRule<Order>(rule);
+            bool passes       = compiledRule(order);
+            Assert.IsTrue(passes);
+
+            order.Items[0].Cost = 4m;
+            passes              = compiledRule(order);
+            Assert.IsFalse(passes);
+        }
     }
 }

--- a/MicroRuleEngine.Core.Tests/ExampleUsage.cs
+++ b/MicroRuleEngine.Core.Tests/ExampleUsage.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MicroRuleEngine.Core.Tests.Models;
+using Newtonsoft.Json;
 
 namespace MicroRuleEngine.Tests
 {
@@ -382,6 +383,47 @@ namespace MicroRuleEngine.Tests
 
             MRE  engine       = new MRE();
             var  compiledRule = engine.CompileRule<OrderParent>(rule);
+            bool passes       = compiledRule(orderParent);
+            Assert.IsFalse(passes);
+
+            order.Items.Add(new Item());
+            order.Items.Add(new Item());
+
+            passes = compiledRule(orderParent);
+
+            Assert.IsTrue(passes);
+        }
+
+        [TestMethod]
+        public void SerializeThenDeserialize()
+        {
+            
+
+
+            Order order = GetOrder();
+
+            var orderParent = new OrderParent() {PlacedOrder = order};
+
+
+            Rule rule = new Rule
+                        {
+                            MemberName = "PlacedOrder.Items",
+                            EnumerableValueExpression = new Selector
+                                                        {
+                                                            Operator = "Count"
+                                                        },
+                            Operator    = "GreaterThan",
+                            TargetValue = 3
+                        };
+
+            var jsonString = JsonConvert.SerializeObject(rule);
+
+            var deserializedRule = JsonConvert.DeserializeObject<Rule>(jsonString);
+
+
+
+            MRE  engine       = new MRE();
+            var  compiledRule = engine.CompileRule<OrderParent>(deserializedRule);
             bool passes       = compiledRule(orderParent);
             Assert.IsFalse(passes);
 

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -27,8 +27,8 @@ namespace MicroRuleEngine
         private static readonly Tuple<string, Lazy<MethodInfo>>[] _enumrMethodsByName =
             new Tuple<string, Lazy<MethodInfo>>[]
             {
-                Tuple.Create("Any", new Lazy<MethodInfo>(() => GetLinqMethod("Any", 2))),
-                Tuple.Create("All", new Lazy<MethodInfo>(() => GetLinqMethod("All", 2))),
+                Tuple.Create("Any",   new Lazy<MethodInfo>(() => GetLinqMethod("Any",   2))),
+                Tuple.Create("All",   new Lazy<MethodInfo>(() => GetLinqMethod("All",   2))),
             };
         private static readonly Lazy<MethodInfo> _miIntTryParse = new Lazy<MethodInfo>(() =>
             typeof(Int32).GetMethod("TryParse", new Type[] { typeof(string), Type.GetType("System.Int32&") }));
@@ -42,7 +42,7 @@ namespace MicroRuleEngine
         private static readonly Lazy<MethodInfo> _miDecimalTryParse = new Lazy<MethodInfo>(() =>
             typeof(Decimal).GetMethod("TryParse", new Type[] { typeof(string), Type.GetType("System.Decimal&") }));
 
-        public Func<T, bool> CompileRule<T>(Rule r)
+        public Func<T, bool>CompileRule<T>(Rule r)
         {
             var paramUser = Expression.Parameter(typeof(T));
             Expression expr = GetExpressionForRule(typeof(T), r, paramUser);
@@ -267,6 +267,50 @@ namespace MicroRuleEngine
                 propExpression = GetProperty(param, rule.MemberName);
                 propType = propExpression.Type;
             }
+
+            if(typeof(IEnumerable).IsAssignableFrom(propType))
+            {
+                if (rule.EnumerableFilter != null)
+                {
+                    var elementType = ElementType(propType);
+                    var lambdaParam = Expression.Parameter(elementType,
+                                                           "lambdaParam");
+                    propExpression = Expression.Call(GetLinqMethod("Where",
+                                                                   2)
+                                                        .MakeGenericMethod(elementType),
+                                                     propExpression,
+                                                     Expression.Lambda(BuildExpr(elementType,
+                                                                           rule.EnumerableFilter,
+                                                                           lambdaParam),
+                                                                       lambdaParam));
+
+
+                }
+
+                if(rule.EnumerableValueExpression != null)
+                {
+                    Type                elementType = ElementType(propType);
+                    ParameterExpression parameter   = Expression.Parameter(elementType, "s");
+                    PropertyInfo        property    = elementType.GetProperty(rule.EnumerableValueExpression.MemberName);
+                    Expression selector = Expression.Lambda(Expression.MakeMemberAccess(parameter,
+                                                                property),
+                                                            parameter);
+
+                    MethodInfo generationMethod = GetLinqMethod(rule.EnumerableValueExpression.Operator,
+                                                                2,
+                                               property.PropertyType);
+
+                    var m = generationMethod.MakeGenericMethod(elementType);
+
+                    propExpression = Expression.Call(m,
+                                                  propExpression,
+                                                  selector);
+
+
+                    propType = propExpression.Type;
+                }
+            }
+
             if (useTryCatch)
             {
                 propExpression = Expression.TryCatch(
@@ -274,6 +318,9 @@ namespace MicroRuleEngine
                     Expression.Catch(typeof(NullReferenceException), Expression.Default(propExpression.Type))
                 );
             }
+
+            
+
 
             // is the operator a known .NET operator?
             ExpressionType tBinary;
@@ -395,6 +442,12 @@ namespace MicroRuleEngine
         {
             return typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public)
                 .FirstOrDefault(m => m.Name == name && m.GetParameters().Length == numParameter);
+        }
+
+        private static MethodInfo GetLinqMethod(string name, int numParameter, Type returnType)
+        {
+            return typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                                     .FirstOrDefault((m => m.Name == name && m.GetParameters().Length == numParameter && m.ReturnType == returnType));
         }
 
 
@@ -696,19 +749,27 @@ namespace MicroRuleEngine
     }
 
     [DataContract]
-    public class Rule
+    public class Selector
+    {
+        [DataMember] public string MemberName { get; set; }
+        [DataMember] public string Operator   { get; set; }
+    }
+
+
+    [DataContract]
+    public class Rule : Selector
     {
         public Rule()
         {
             Inputs = Enumerable.Empty<object>();
         }
-
-        [DataMember] public string MemberName { get; set; }
-        [DataMember] public string Operator { get; set; }
+        
         [DataMember] public object TargetValue { get; set; }
-        [DataMember] public IList<Rule> Rules { get; set; }
-        [DataMember] public IEnumerable<object> Inputs { get; set; }
 
+        [DataMember] public Rule                EnumerableFilter      { get; set; }
+        [DataMember] public Selector            EnumerableValueExpression { get; set; }
+        [DataMember] public IList<Rule>         Rules           { get; set; }
+        [DataMember] public IEnumerable<object> Inputs          { get; set; }
 
         public static Rule operator |(Rule lhs, Rule rhs)
         {

--- a/MicroRuleEngine/MRE.cs
+++ b/MicroRuleEngine/MRE.cs
@@ -328,9 +328,21 @@ namespace MicroRuleEngine
                                                                 2,
                                                property.PropertyType);
 
+                    
+
                     if(generationMethod == null)
                     {
                         generationMethod = GetLinqMethod(rule.EnumerableValueExpression.Operator, rule.TargetValue.GetType());
+                    }
+                    if(generationMethod == null)
+                    {
+                        generationMethod = GetLinqMethod(rule.EnumerableValueExpression.Operator);
+                    }
+
+                    if (generationMethod == null)
+                    {
+                        throw new
+                            RulesException($"Unable to find Linq method for {rule.EnumerableValueExpression.Operator}");
                     }
 
                     var m = generationMethod.MakeGenericMethod(elementType);
@@ -490,6 +502,12 @@ namespace MicroRuleEngine
         {
             return typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public)
                                      .FirstOrDefault((m => m.Name == name && m.ReturnType == returnType));
+        }
+
+        private static MethodInfo GetLinqMethod(string name)
+        {
+            return typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                                     .FirstOrDefault((m => m.Name == name));
         }
 
 


### PR DESCRIPTION
Added functionality to filter then aggregate `IEnumerable` properties to then use as the left hand input to an operator.

This only occurs when the `MemberName` is an `IEnumerable` and the `EnumerableFilter` or `EnumerableValueExpression`  are populated.